### PR TITLE
Reset state variables when creating a new indexer

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -6,6 +6,8 @@ var maxFiles = 0;
 
 function Indexer(setup) {
 	this.setup = setup;
+	algoliaIdx = []; 
+	maxFiles = 0;
 }
 
 Indexer.prototype.run = function(){


### PR DESCRIPTION
State variables kept their value when creating a new indexer, which led to errors.